### PR TITLE
Request signed URLs when querying for publications

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -248,7 +248,8 @@ class repository_opencast extends repository {
 
         $api = new api($ocinstanceid);
 
-        $query = '/api/events/' . $video->identifier . '/publications/';
+        // Use sign=true parameter to get signed URLs when Opencasts URL signing is turned on. sign=true does not harm when turned off.
+        $query = '/api/events/' . $video->identifier . '/publications?sign=true';
         $result = $api->oc_get($query);
         $publications = json_decode($result);
 


### PR DESCRIPTION
Add sign=true parameter to event publications API request.

fixes #20 