### PR TITLE
Disable metadata

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -292,7 +292,7 @@ class repository_opencast extends repository {
 
             $seriesfilter = "series:" . $seriesid;
 
-            $query = '/api/events?sign=true&withmetadata=true&withpublications=true&filter=' . urlencode($seriesfilter);
+            $query = '/api/events?sign=true&withmetadata=false&withpublications=true&filter=' . urlencode($seriesfilter);
             try {
                 $api = new api($ocinstanceid);
                 $seriesvideos = $api->oc_get($query);


### PR DESCRIPTION
This removes an unnecessary query parameter, reducing query time and helping to prevent timeouts.

Comparable to this PR in block_opencast: https://github.com/Opencast-Moodle/moodle-block_opencast/pull/342