### PR TITLE
Make sure repository uses Opencat PHP library

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -290,14 +290,19 @@ class repository_opencast extends repository {
                 continue;
             }
 
-            $seriesfilter = "series:" . $seriesid;
-
-            $query = '/api/events?sign=true&withmetadata=false&withpublications=true&filter=' . urlencode($seriesfilter);
+            $params = [
+                'sign' => true,
+                'withmetadata' => false,
+                'withpublications' => true,
+            ];
             try {
-                $api = new api($ocinstanceid);
-                $seriesvideos = $api->oc_get($query);
-                $seriesvideos = json_decode($seriesvideos);
-                $videos = array_merge($videos, $seriesvideos);
+                $api = api::get_instance($ocinstanceid);
+                $response = $api->opencastapi->eventsApi->getBySeries($seriesid, $params);
+                $code = $response['code'];
+                if ($code == 200) {
+                    $seriesvideos = $response['body'];
+                    $videos = array_merge($videos, $seriesvideos);
+                }
             } catch (\moodle_exception $e) {
                 continue;
             }


### PR DESCRIPTION
This PR fixes #38,

### Description  
After reviewing the usage of the old cURL API call in the `tool_opencast` plugin, I identified only one instance where the `get` method is being used.  

### Solution 
This PR contains using the `opencastapi` property within the `api` class of the `tool_opencast` plugin while ensuring that the required behavior remains unchanged.  

### Testing Instructions  

1. Apply this PR to your setup.  
2. Ensure that the plugin is correctly configured.  
3. Use the plugin alongside the `filter_opencast` plugin to access the video selection interface from the Opencast repository.  
4. Verify that the displayed list of videos is correct and includes all videos from the selected series.  
